### PR TITLE
Menu Custom Fields

### DIFF
--- a/resources/views/mega-menu.blade.php
+++ b/resources/views/mega-menu.blade.php
@@ -69,7 +69,7 @@ $menu = Navi::build($name);
                         $ungrouped = [];
                         
                         foreach ($item->children as $child) {
-                          $category = $child->meta('category') ?? '';
+                          $category = $child->category ?? '';
                           if (!empty($category)) {
                             if (!isset($groupedChildren[$category])) {
                               $groupedChildren[$category] = [];
@@ -90,8 +90,8 @@ $menu = Navi::build($name);
                                 <li class="mega-menu-item py-2 hover:text-white" role="none">
                                   <a href="{{ $child->url }}" role="menuitem" class="no-underline block">
                                     {{ $child->label }}
-                                    @if ($child->meta('description'))
-                                      <span class="block text-xs text-gray-400 mt-1">{{ $child->meta('description') }}</span>
+                                    @if ($child->description)
+                                      <span class="block text-xs text-gray-400 mt-1">{{ $child->description }}</span>
                                     @endif
                                   </a>
                                 </li>
@@ -117,16 +117,16 @@ $menu = Navi::build($name);
                       @endif
                       
                       <!-- Featured content section -->
-                      @if ($item->meta('featured_image') || $item->meta('featured_text'))
+                      @if ($item->featured_image || $item->featured_text)
                         <div class="md:w-1/4 mb-6 md:mb-0 px-2">
-                          @if ($item->meta('featured_image'))
+                          @if ($item->featured_image)
                             <div class="mb-4">
-                              <img src="{{ $item->meta('featured_image') }}" alt="Featured" class="w-full rounded">
+                              <img src="{{ $item->featured_image }}" alt="Featured" class="w-full rounded">
                             </div>
                           @endif
-                          @if ($item->meta('featured_text'))
+                          @if ($item->featured_text)
                             <div class="text-sm text-textbodygray">
-                              {!! $item->meta('featured_text') !!}
+                              {!! $item->featured_text !!}
                             </div>
                           @endif
                         </div>

--- a/src/MenuFields.php
+++ b/src/MenuFields.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Imagewize\ImgMegaMenu;
+
+class MenuFields
+{
+    /**
+     * Register the menu fields.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        add_action('wp_nav_menu_item_custom_fields', [$this, 'addCustomFields'], 10, 4);
+        add_action('wp_update_nav_menu_item', [$this, 'saveCustomFields'], 10, 3);
+        add_filter('wp_setup_nav_menu_item', [$this, 'setupMenuItem']);
+    }
+
+    /**
+     * Add custom fields to menu item admin screen.
+     *
+     * @param int $item_id
+     * @param object $item
+     * @param int $depth
+     * @param array $args
+     * @return void
+     */
+    public function addCustomFields($item_id, $item, $depth, $args)
+    {
+        // Category field
+        $category = get_post_meta($item_id, '_menu_item_category', true);
+        ?>
+        <div class="field-category description-wide" style="margin: 5px 0;">
+            <label for="edit-menu-item-category-<?php echo $item_id; ?>">
+                <?php _e('Category (for mega menu grouping)', 'img-mega-menu'); ?><br>
+                <input type="text" id="edit-menu-item-category-<?php echo $item_id; ?>" 
+                       class="widefat" name="menu-item-category[<?php echo $item_id; ?>]" 
+                       value="<?php echo esc_attr($category); ?>">
+                <span class="description"><?php _e('Group this menu item under a category in the megamenu (optional)', 'img-mega-menu'); ?></span>
+            </label>
+        </div>
+        <?php
+
+        // Description field
+        $description = get_post_meta($item_id, '_menu_item_mega_description', true);
+        ?>
+        <div class="field-mega-description description-wide" style="margin: 5px 0;">
+            <label for="edit-menu-item-mega-description-<?php echo $item_id; ?>">
+                <?php _e('Description (for mega menu)', 'img-mega-menu'); ?><br>
+                <textarea id="edit-menu-item-mega-description-<?php echo $item_id; ?>" 
+                       class="widefat" name="menu-item-mega-description[<?php echo $item_id; ?>]" 
+                       rows="3"><?php echo esc_textarea($description); ?></textarea>
+                <span class="description"><?php _e('Short description to display under the menu item', 'img-mega-menu'); ?></span>
+            </label>
+        </div>
+        <?php
+
+        // Featured image field
+        $featured_image = get_post_meta($item_id, '_menu_item_featured_image', true);
+        ?>
+        <div class="field-featured-image description-wide" style="margin: 5px 0;">
+            <label for="edit-menu-item-featured-image-<?php echo $item_id; ?>">
+                <?php _e('Featured Image URL (for mega menu)', 'img-mega-menu'); ?><br>
+                <input type="text" id="edit-menu-item-featured-image-<?php echo $item_id; ?>" 
+                       class="widefat" name="menu-item-featured-image[<?php echo $item_id; ?>]" 
+                       value="<?php echo esc_attr($featured_image); ?>">
+                <span class="description"><?php _e('Image URL to show in the megamenu (for parent items)', 'img-mega-menu'); ?></span>
+            </label>
+        </div>
+        <?php
+
+        // Featured text field
+        $featured_text = get_post_meta($item_id, '_menu_item_featured_text', true);
+        ?>
+        <div class="field-featured-text description-wide" style="margin: 5px 0;">
+            <label for="edit-menu-item-featured-text-<?php echo $item_id; ?>">
+                <?php _e('Featured Text (for mega menu)', 'img-mega-menu'); ?><br>
+                <textarea id="edit-menu-item-featured-text-<?php echo $item_id; ?>" 
+                       class="widefat" name="menu-item-featured-text[<?php echo $item_id; ?>]" 
+                       rows="4"><?php echo esc_textarea($featured_text); ?></textarea>
+                <span class="description"><?php _e('Content to show in the featured section (for parent items)', 'img-mega-menu'); ?></span>
+            </label>
+        </div>
+        <?php
+    }
+
+    /**
+     * Save the custom field values.
+     *
+     * @param int $menu_id
+     * @param int $menu_item_db_id
+     * @param array $args
+     * @return void
+     */
+    public function saveCustomFields($menu_id, $menu_item_db_id, $args)
+    {
+        // Save category
+        if (isset($_POST['menu-item-category'][$menu_item_db_id])) {
+            update_post_meta(
+                $menu_item_db_id, 
+                '_menu_item_category', 
+                sanitize_text_field($_POST['menu-item-category'][$menu_item_db_id])
+            );
+        }
+
+        // Save description
+        if (isset($_POST['menu-item-mega-description'][$menu_item_db_id])) {
+            update_post_meta(
+                $menu_item_db_id, 
+                '_menu_item_mega_description', 
+                sanitize_textarea_field($_POST['menu-item-mega-description'][$menu_item_db_id])
+            );
+        }
+
+        // Save featured image
+        if (isset($_POST['menu-item-featured-image'][$menu_item_db_id])) {
+            update_post_meta(
+                $menu_item_db_id, 
+                '_menu_item_featured_image', 
+                esc_url_raw($_POST['menu-item-featured-image'][$menu_item_db_id])
+            );
+        }
+
+        // Save featured text
+        if (isset($_POST['menu-item-featured-text'][$menu_item_db_id])) {
+            update_post_meta(
+                $menu_item_db_id, 
+                '_menu_item_featured_text', 
+                wp_kses_post($_POST['menu-item-featured-text'][$menu_item_db_id])
+            );
+        }
+    }
+
+    /**
+     * Add custom fields to menu item.
+     *
+     * @param object $menu_item
+     * @return object
+     */
+    public function setupMenuItem($menu_item)
+    {
+        // Add our custom meta as properties of the menu item object
+        $menu_item->category = get_post_meta($menu_item->ID, '_menu_item_category', true);
+        $menu_item->description = get_post_meta($menu_item->ID, '_menu_item_mega_description', true);
+        $menu_item->featured_image = get_post_meta($menu_item->ID, '_menu_item_featured_image', true);
+        $menu_item->featured_text = get_post_meta($menu_item->ID, '_menu_item_featured_text', true);
+
+        return $menu_item;
+    }
+}

--- a/src/Providers/ImgMegaMenuServiceProvider.php
+++ b/src/Providers/ImgMegaMenuServiceProvider.php
@@ -4,6 +4,7 @@ namespace Imagewize\ImgMegaMenu\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Imagewize\ImgMegaMenu\MegaMenu;
+use Imagewize\ImgMegaMenu\MenuFields;
 
 class ImgMegaMenuServiceProvider extends ServiceProvider
 {
@@ -39,5 +40,11 @@ class ImgMegaMenuServiceProvider extends ServiceProvider
             __DIR__.'/../../resources/views',
             'img-mega-menu',
         );
+        
+        // Register menu fields for the mega menu
+        add_action('init', function () {
+            $menuFields = new MenuFields();
+            $menuFields->register();
+        });
     }
 }


### PR DESCRIPTION
This pull request focuses on enhancing the mega menu functionality by introducing custom fields for menu items and simplifying the template logic. The most important changes include adding a new `MenuFields` class to handle custom fields, updating the service provider to register these fields, and modifying the Blade template to use the new properties directly.

Enhancements to mega menu functionality:

* [`src/MenuFields.php`](diffhunk://#diff-34a084c5456317b54ece4060308e9c71711bb5541ad6ab42192e43fb00ac8c66R1-R150): Added a new `MenuFields` class to handle the registration, addition, and saving of custom fields for menu items, including category, description, featured image, and featured text.
* [`src/Providers/ImgMegaMenuServiceProvider.php`](diffhunk://#diff-fbc4b3d65b772c1a0e3f0693cbd1eec8ed2fdbbdd4e319058bb0bc5cd6ed395fR7): Updated the service provider to include the `MenuFields` class and register the custom fields during the `init` action. [[1]](diffhunk://#diff-fbc4b3d65b772c1a0e3f0693cbd1eec8ed2fdbbdd4e319058bb0bc5cd6ed395fR7) [[2]](diffhunk://#diff-fbc4b3d65b772c1a0e3f0693cbd1eec8ed2fdbbdd4e319058bb0bc5cd6ed395fR43-R48)

Simplification of Blade template logic:

* [`resources/views/mega-menu.blade.php`](diffhunk://#diff-db05a291d776e6a42807c16f873ca14232c31a2d82b21fe1e30fceed8243406cL72-R72): Replaced calls to `$item->meta()` with direct property accesses (`$item->category`, `$item->description`, `$item->featured_image`, and `$item->featured_text`) to utilize the new custom fields. [[1]](diffhunk://#diff-db05a291d776e6a42807c16f873ca14232c31a2d82b21fe1e30fceed8243406cL72-R72) [[2]](diffhunk://#diff-db05a291d776e6a42807c16f873ca14232c31a2d82b21fe1e30fceed8243406cL93-R94) [[3]](diffhunk://#diff-db05a291d776e6a42807c16f873ca14232c31a2d82b21fe1e30fceed8243406cL120-R129)